### PR TITLE
fix(ci): Failed to release to github with status 403

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*
+permissions:
+  contents: write
 jobs:
   release:
     name: Publish to Github Releases
@@ -87,6 +89,7 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cross
+      - uses: Swatinem/rust-cache@v2
       - name: Show Version Information (Rust, cargo, GCC)
         shell: bash
         run: |


### PR DESCRIPTION
这个PR

* 修复了上次提交的 v0.1.0 的release actions失败 https://github.com/NavyD/syncdir/actions/runs/6704014808/job/18215602260 出现403错误

    ```
    Run softprops/action-gh-release@v1
    👩‍🏭 Creating new GitHub release for tag v0.1.0...
    ⚠️ GitHub release failed with status: 403
    undefined
    ```

    参考 https://github.com/softprops/action-gh-release/issues/236#issuecomment-1150530128 在actions文件中添加write权限

    ```yml
    permissions:
      contents: write
    ```

* 添加[rust-cache](https://github.com/Swatinem/rust-cache)尝试加速CI构建速度